### PR TITLE
Fix: ES-32,6,7 - Folder/File name validation issues

### DIFF
--- a/packages/editor/src/reducers/utils/fileUtils.ts
+++ b/packages/editor/src/reducers/utils/fileUtils.ts
@@ -21,12 +21,12 @@ export function isSolitidyFile(item: IProjectItem): boolean {
     return item.type === ProjectItemTypes.File && item.name.toLowerCase().endsWith('.sol');
 }
 
-const UNIX_RESERVED_CHARS_REGEX = /[<>:"\/\\|?*\x00-\x1F]/g;
+const UNIX_RESERVED_CHARS_REGEX = /[<>:"\/\\|?*\x00-\x1F]/;
 const WINDOWS_RESERVED_CHARS_REGEX = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])$/i;
 
 export function isValidProjectItemName(name: string): boolean {
     name = name.trim();
-    return name.length > 0 && name.length < 255 && !UNIX_RESERVED_CHARS_REGEX.test(name) && !WINDOWS_RESERVED_CHARS_REGEX.test(name) && name.indexOf('/') === -1;
+    return name.length > 0 && name.length < 255 && !UNIX_RESERVED_CHARS_REGEX.test(name) && !WINDOWS_RESERVED_CHARS_REGEX.test(name);
 }
 
 // Insert path into directory tree structure:

--- a/packages/editor/src/reducers/utils/fileUtils.ts
+++ b/packages/editor/src/reducers/utils/fileUtils.ts
@@ -26,7 +26,7 @@ const WINDOWS_RESERVED_CHARS_REGEX = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])$/i;
 
 export function isValidProjectItemName(name: string): boolean {
     name = name.trim();
-    return name.length > 0 && name.length < 255 && !UNIX_RESERVED_CHARS_REGEX.test(name) && !WINDOWS_RESERVED_CHARS_REGEX.test(name);
+    return name.length > 0 && name.length < 255 && !UNIX_RESERVED_CHARS_REGEX.test(name) && !WINDOWS_RESERVED_CHARS_REGEX.test(name) && name.indexOf('/') === -1;
 }
 
 // Insert path into directory tree structure:


### PR DESCRIPTION
> Renaming HelloWorld.sol to /app/HelloWorld.sol returns "Invalid file or folder name"
Renaming HelloWorld.sol to app/HelloWorld.sol doesn't move it to app directory, but adds the forward slash as part of the file name instead

Moving files with renaming was replaced with drag & drop feature, but the forward slash issue, should be fixed in this PR.

EDIT: Also fixes ES-6,7 as the issue was there because of the wrong name validation