### PR TITLE
Add: ES-42 - Implement auto scroll in output & messages panels

### DIFF
--- a/packages/editor/src/components/projectEditor/panels/messagesPanel/MessagesPanel.tsx
+++ b/packages/editor/src/components/projectEditor/panels/messagesPanel/MessagesPanel.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Superblocks Lab.  If not, see <http://www.gnu.org/licenses/>.
 
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import classNames from 'classnames';
 import style from '../../style-console.less';
 import { IMessageLogRow } from '../../../../models/state';
@@ -30,7 +30,19 @@ function getTime(row: IMessageLogRow) {
     return row.timestamp.getHours() + ':' + row.timestamp.getMinutes();
 }
 
-export function MessagesPanel(props: IProps) {
+export const MessagesPanel = (props: IProps) => {
+    const messagesAnchor: any = useRef(null);
+
+    const scrollToBottom = () => {
+        if (messagesAnchor !== null && messagesAnchor.current !== null) {
+            messagesAnchor.current.scrollIntoView({ behavior: 'smooth' });
+        }
+    };
+
+    useEffect(() => {
+        scrollToBottom();
+    });
+
     return (
         <div className='scrollable-y'>
             <div className={style.console}>
@@ -49,8 +61,9 @@ export function MessagesPanel(props: IProps) {
                             return <div key={index + lineIndex} className={cl}>{getTime(row)}<span>&nbsp;&nbsp;&nbsp;&nbsp;</span>{line}</div>;
                         });
                     })}
+                    <div ref={messagesAnchor} />
                 </div>
             </div>
         </div>
     );
-}
+};

--- a/packages/editor/src/components/projectEditor/panels/output/OutputPanel.tsx
+++ b/packages/editor/src/components/projectEditor/panels/output/OutputPanel.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Superblocks Lab.  If not, see <http://www.gnu.org/licenses/>.
 
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import classNames from 'classnames';
 import style from '../../style-console.less';
 import { IOutputLogRow } from '../../../../models/state';
@@ -26,7 +26,19 @@ interface IProps {
     clearOutputLog: () => void;
 }
 
-export function OutputPanel(props: IProps) {
+export const OutputPanel = (props: IProps) => {
+    const messagesAnchor: any = useRef(null);
+
+    const scrollToBottom = () => {
+        if (messagesAnchor !== null && messagesAnchor.current !== null) {
+            messagesAnchor.current.scrollIntoView({ behavior: 'smooth' });
+        }
+    };
+
+    useEffect(() => {
+        scrollToBottom();
+    });
+
     return (
         <div className='scrollable-y'>
             <div className={style.console}>
@@ -51,8 +63,9 @@ export function OutputPanel(props: IProps) {
                             return <div key={index + lineIndex} className={cl}>{line}</div>;
                         });
                     })}
+                    <div ref={messagesAnchor} />
                 </div>
             </div>
         </div>
     );
-}
+};


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
When a new message is added in `Output` or  `Messages` panel, it auto scrolls to the bottom so the user doesn't have to scroll manually.