### PR TITLE
Fix: ES-5 - Setting either Gas Limit or Gas Price using up and down arrows in Chain Network Preferences resets the fields to the default values after saving

### DIFF
--- a/packages/editor/src/components/common/textInput/index.js
+++ b/packages/editor/src/components/common/textInput/index.js
@@ -45,7 +45,7 @@ export class TextInput extends PureComponent {
                         <input
                             id={id}
                             type={type}
-                            onKeyUp={onChangeText}
+                            onChange={onChangeText}
                             defaultValue={defaultValue}
                             disabled={disabled}
                             readOnly={readOnly}


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### What was the issue

> Setting either Gas Limit or Gas Price using up and down arrows in Chain Network Prefereces resets the fields to the default values after Save.

> Go to Preferences (gear icon), then set both the Gas Limit and Gas Price to 1 and 1. Click save and exit.
Verify the status bar reads Gas Limit 1 and Gas Price 0.000000001.

> Reopen Preferences, then use the up arrow to increase the Gas Limit to 2. Save.
Verify the status bar now reads Gas Limit 7900000 and Gas Price 1

> Changing either one of the fields and using the down arrow instead occurs in the same reset behavior.
