### PR TITLE
Fix: ES-8,48 - Several fixes for export project functionality

### DIFF
--- a/packages/editor/src/epics/projects/exportProject.epic.ts
+++ b/packages/editor/src/epics/projects/exportProject.epic.ts
@@ -35,8 +35,16 @@ export const exportProject = (action$: AnyAction, state$: any) => action$.pipe(
         const zip = new JSZip();
         const fileName = state.projects.project.name.trim().toLowerCase().replace(' ', '_') + '_' + Date.now();
 
+        let includeBuildFiles = false;
+        if (confirm('Do you also want to save the project state (current contract addresses, ABIs, etc...)?')) {
+            includeBuildFiles = true;
+        }
+
         // Add all files to zip variable
         traverseTree(files, (file, path) => {
+            if (!includeBuildFiles && path()[0] === 'build') {
+                return;
+            }
             if (file.type !== ProjectItemTypes.Folder) {
                 zip.file(pathToString(path()), file.code);
             } else if (file.type === ProjectItemTypes.Folder && !file.children.length) {

--- a/packages/editor/src/epics/projects/exportProject.epic.ts
+++ b/packages/editor/src/epics/projects/exportProject.epic.ts
@@ -22,6 +22,7 @@ import { ProjectItemTypes } from '../../models';
 import { traverseTree } from '../../reducers/explorerLib';
 import JSZip from 'jszip';
 import FileSaver from 'file-saver';
+import { empty } from 'rxjs';
 
 function pathToString(path: string[]) {
     return '/' + path.join('/');
@@ -35,10 +36,19 @@ export const exportProject = (action$: AnyAction, state$: any) => action$.pipe(
         const zip = new JSZip();
         const fileName = state.projects.project.name.trim().toLowerCase().replace(/ /g, '_') + '_' + Date.now();
 
-        let includeBuildFiles = false;
-        if (confirm('Do you also want to save the project state (current contract addresses, ABIs, etc...)?')) {
-            includeBuildFiles = true;
+        const promptResult = prompt(
+            'Do you also want to save the project state (current contract addresses, ABIs, etc...)?',
+            'yes'
+        );
+        if (!promptResult) {
+            return empty();
         }
+        const promptResultLowerCase = promptResult.toLowerCase();
+        if (promptResultLowerCase !== 'yes' && promptResultLowerCase !== 'no') {
+            alert('Download aborted. Yes or No answer expected.');
+            return empty();
+        }
+        const includeBuildFiles = promptResultLowerCase === 'yes';
 
         // Add all files to zip variable
         traverseTree(files, (file, path) => {

--- a/packages/editor/src/epics/projects/exportProject.epic.ts
+++ b/packages/editor/src/epics/projects/exportProject.epic.ts
@@ -33,7 +33,7 @@ export const exportProject = (action$: AnyAction, state$: any) => action$.pipe(
     switchMap(([, state]) => {
         const files = state.explorer.tree;
         const zip = new JSZip();
-        const fileName = state.projects.project.name.trim().toLowerCase().replace(' ', '_') + '_' + Date.now();
+        const fileName = state.projects.project.name.trim().toLowerCase().replace(/ /g, '_') + '_' + Date.now();
 
         let includeBuildFiles = false;
         if (confirm('Do you also want to save the project state (current contract addresses, ABIs, etc...)?')) {

--- a/packages/editor/src/epics/projects/exportProject.epic.ts
+++ b/packages/editor/src/epics/projects/exportProject.epic.ts
@@ -33,6 +33,7 @@ export const exportProject = (action$: AnyAction, state$: any) => action$.pipe(
     switchMap(([, state]) => {
         const files = state.explorer.tree;
         const zip = new JSZip();
+        const fileName = state.projects.project.name.trim().toLowerCase().replace(' ', '_') + '_' + Date.now();
 
         // Add all files to zip variable
         traverseTree(files, (file, path) => {
@@ -46,7 +47,7 @@ export const exportProject = (action$: AnyAction, state$: any) => action$.pipe(
         // Generate zip and show pop up
         zip.generateAsync({type: 'blob'})
             .then((content: any) => {
-                FileSaver.saveAs(content, 'test.zip');
+                FileSaver.saveAs(content, `${fileName}.zip`);
             });
 
         return [projectsActions.exportProjectSuccess()];

--- a/packages/editor/src/epics/projects/exportProject.epic.ts
+++ b/packages/editor/src/epics/projects/exportProject.epic.ts
@@ -38,6 +38,8 @@ export const exportProject = (action$: AnyAction, state$: any) => action$.pipe(
         traverseTree(files, (file, path) => {
             if (file.type !== ProjectItemTypes.Folder) {
                 zip.file(pathToString(path()), file.code);
+            } else if (file.type === ProjectItemTypes.Folder && !file.children.length) {
+                zip.folder(pathToString(path()), file.name);
             }
         });
 


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
Solves ES-8 and 48
- When exporting project, include empty folders
- When exporting project, ask user if export should include build folder
- Fix wrong name of exported file
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Verification Process
1. Open up any project
2. Create an empty folder inside project
3. Navigate to Topbar menu (left top hamburger) -> click File - Export project

3.1 - Exported file should be named `$projectName_$currentTimeStamp`
3.2 - Exported file should include empty folders
3.3 - If user enters `Yes` on the prompt, exported file should include `build` folder
3.4 - If user enters `No` on prompt, exported file shouldn't include `build` folder

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->