### PR TITLE
Fix: ES-15 - Transaction history deploy contract missing contract name

### DIFF
--- a/packages/editor/src/reducers/transactionsLib/formatTransaction.ts
+++ b/packages/editor/src/reducers/transactionsLib/formatTransaction.ts
@@ -28,7 +28,7 @@ export function formatTransaction(state: any, transactionType: TransactionType, 
         hash: hash || '',
         index: receipt ? receipt.transactionIndex : 'n/a',
         type: transactionType,
-        contractName: contractName || '',
+        contractName: contractName || receipt,
         constructorArgs: [], // TODO: Add args
         createdAt: Date.now(),
         blockNumber: receipt ? receipt.blockNumber : 'n/a',


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
Fixes ES-15

> Transactions History reads "Deploy" instead of "Deploy <contract name>" for unconfirmed or unfinished transactions


### Verification Process
1. Open Transactions panel
2. Deploy to `Ropsten` or any other test network
3. Transaction title should read as `Deploy <Contract Name>`  instead `Deploy`
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->
