### PR TITLE
Fix: ES-22 - Properly handle error while renaming project

### DIFF
--- a/packages/editor/src/components/toasts/index.tsx
+++ b/packages/editor/src/components/toasts/index.tsx
@@ -71,6 +71,8 @@ export const getToastComponent = (type: string) => {
             return error('Ups. Error while forking. Please try again');
         case projectsActions.UPDATE_PROJECT_SETTINGS_FAIL:
             return error('Ups. Error updating project settings');
+        case projectsActions.RENAME_PROJECT_FAIL:
+            return error('Ups. Error renaming project. No special characters allowed.');
         case projectsActions.CREATE_PROJECT_SUCCESS:
             return success('Project created!');
         case projectsActions.DELETE_PROJECT_FAIL:

--- a/packages/editor/src/epics/projects/renameProject.epic.ts
+++ b/packages/editor/src/epics/projects/renameProject.epic.ts
@@ -42,10 +42,10 @@ export const renameProjectEpic: Epic = (action$: any, state$: any) => action$.pi
                 .pipe(
                     switchMap(() => projectService.getProjectById(project.id)),
                     map(projectsActions.updateProjectSuccess),
+                    catchError(err => [projectsActions.renameProjectFail(err)])
                 );
         } else {
             return EMPTY;
         }
     }),
-    catchError(err => [projectsActions.renameProjectFail(err)])
 );

--- a/packages/editor/src/reducers/toast.reducer.ts
+++ b/packages/editor/src/reducers/toast.reducer.ts
@@ -40,6 +40,7 @@ export default function toastsReducer(state = initialState, action: AnyAction, r
         case projectsActions.FORK_PROJECT:
         case projectsActions.CREATE_PROJECT_SUCCESS:
         case projectsActions.DELETE_PROJECT_FAIL:
+        case projectsActions.RENAME_PROJECT_FAIL:
         case projectsActions.FORK_PROJECT_FAIL: {
             return pushToastToState();
         }


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
Fixes ES-22:
> Renaming project to contain special characters results in silent failure

While renaming project and including special characters, it would silently fail and it wouldn't be possible to rename the project anymore, until user reloads the application.

Steps to verify:
1. Open project
2. Rename project to `Patata` -> project should be renamed
3. Rename project to `/Illegal Patata` -> toast with error should appear
4. Rename project to `Banana` -> project should be successfully renamed. 