### PR TITLE
ES-35 - Fix openFile query string propagating into share functionality

### DIFF
--- a/packages/editor/src/components/topbar/Topbar.tsx
+++ b/packages/editor/src/components/topbar/Topbar.tsx
@@ -70,7 +70,7 @@ export default class TopBar extends Component<IProps> {
                 showModal('PREFERENCES_MODAL', null);
                 break;
             case 'share':
-                const defaultUrl = String(window.location);
+                const defaultUrl = String(window.location.href.split('?')[0]);
                 showModal('SHARE_MODAL', { defaultUrl });
                 break;
             default:


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
**Issue:** 
> `The query string gets propagated to Share functionality since the address bar is never updated.`

**Fix:**
The url in share modal should now be correct, without any query string

**Verify:**
1. Open share modal (share button in topBar)
2. First url (Editor link) should read `http://localhost:4000/<projectId>` (in local environment)

@filippsen Please double check this one if it actually solves the same issue as in ES-35

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->
