### PR TITLE
Fix ES-58, loading in Opera, without Metamask.

### DIFF
--- a/packages/editor/src/actions/projects.actions.ts
+++ b/packages/editor/src/actions/projects.actions.ts
@@ -137,7 +137,7 @@ export const projectsActions = {
     loadProjectSuccess(project: IProject) {
        return {
             type: projectsActions.LOAD_PROJECT_SUCCESS,
-            data: { project, metamaskAccounts: window.web3 ? window.web3.eth.accounts : [] }
+            data: { project, metamaskAccounts: (window.web3 && window.web3.eth) ? window.web3.eth.accounts : [] }
        };
     },
     LOAD_PROJECT_FAIL: 'LOAD_PROJECT_FAIL',

--- a/packages/editor/src/epics/projects/environmentUpdate.epic.ts
+++ b/packages/editor/src/epics/projects/environmentUpdate.epic.ts
@@ -42,7 +42,7 @@ export const environmentUpdateEpic: Epic = (action$, state$) => action$.pipe(
             selectedEnvironment.name !== Networks.custom.name) {
             return from(window.web3.currentProvider.enable()).pipe(
                 // do nothing if user gives access to metamask
-                switchMap(() => [projectsActions.setMetamaskAccounts(window.web3.eth.accounts), projectsActions.setEnvironmentSuccess()]),
+                switchMap(() => [projectsActions.setMetamaskAccounts((window.web3 && window.web3.eth) ? window.web3.eth.accounts : []), projectsActions.setEnvironmentSuccess()]),
                 // set env back to browser in case user reject metamask access
                 catchError(() => [projectsActions.setEnvironment(Networks.browser.name)])
             );


### PR DESCRIPTION
### Description of the Change
Fixing ES-58 so that application does not crash on Opera without Metamask, where `window.web3` is available but `window.web3.eth` is not.
