### PR TITLE
ES-4 - Removed clean build folder every time compiling

### DIFF
--- a/packages/editor/src/epics/compiler/compileContract.epic.ts
+++ b/packages/editor/src/epics/compiler/compileContract.epic.ts
@@ -34,24 +34,13 @@ function compileContract(compilerState: any) {
     );
 }
 
-function cleanBuildFolder$(tree: IProjectItem) {
-    const buildFolder = findItemByPath(tree, [ 'build' ], ProjectItemTypes.Folder);
-    if (buildFolder === null || !buildFolder) {
-        return empty();
-    }
-
-    return of(explorerActions.deleteItem(buildFolder.id));
-}
-
 export const compileContractsEpic: Epic = (action$: any, state$: any) => action$.pipe(
     ofType(explorerActions.COMPILE_CONTRACT),
     withLatestFrom(state$),
     switchMap(([_action, state]) => {
         compilerService.init();
-
         return concat(
             of(panelsActions.openPanel(Panels.OutputLog)), // show output
-            cleanBuildFolder$(state.explorer.tree),
             interval(200).pipe(
                 first(() => compilerService.isReady()), // compiler has to be ready to be able to do smth
                 switchMap(() => concat(


### PR DESCRIPTION
### Description of the Change

Removed the cleaning of the build folder every time we compile a contract. The original idea of this addition was to start from a clean state every time compiling but I just realized that in fact this has raised a number of issues: 

- When compiling the contract (and therefore removing the build folder) it would also revert the dappfile.json content. 
- Also if we have compiled another contract before, compiling a different one would cause the entire compilation/deployment info of the previous contract to disappear. 

### Possible Drawbacks

None that I can think of as right now. 

### Verification Process

1. Start from Hello World template

2. Compile, then Deploy to make sure the project is in a good starting condition

3. Go to Configure and rename it. Save.

4. Repeat the Compile action. Everything in the contract config should remain the same as before. 

### JIRA Issues

This should resolve JIRA ES-4 issue. 
