### PR TITLE
Fix flicker when opening file

### DIFF
--- a/packages/editor/src/reducers/panes.reducer.ts
+++ b/packages/editor/src/reducers/panes.reducer.ts
@@ -28,9 +28,18 @@ export default function panesReducer(state = initialState, action: AnyAction, ro
     switch (action.type) {
 
         case panesActions.OPEN_FILE: {
+            const currentPane = state.activePane;
+            const activePane = action.data.id;
+
+            if (currentPane === activePane) {
+                return {
+                    ...state
+                };
+            }
+
             const items = replaceInArray(state.items.slice(), p => p.active, p => ({ ...p, active: false }));
             const itemIndex = items.findIndex(i => i.file.id === action.data.id);
-            const activePane = action.data.id;
+
             if (itemIndex >= 0) {
                 items[itemIndex] = { ...items[itemIndex], active: true };
             } else {


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change

This PR addresses the issue of having a small flicker when quickly clicking on an already opened tab. The solution is to check when opening a file whether the file to be opened is already opened.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Benefits

No more flicker.

### Github Issues

<!-- Enter any applicable Issues here -->
Resolves #83