### PR TITLE
Provide the selected account for provider.getAccounts(). Issue #66

### DIFF
--- a/packages/editor/src/components/superProvider/index.ts
+++ b/packages/editor/src/components/superProvider/index.ts
@@ -241,6 +241,8 @@ export default class SuperProvider {
                     sendIframeMessage(error, null);
                 }
             }
+        } else if (payload.method === 'eth_accounts') {
+            sendIframeMessage(null, {id: payload.id, jsonrpc: '2.0', result: [this.selectedAccount.address]});
         } else {
             try {
                 const result = await this.send(data.payload, data.endpoint);


### PR DESCRIPTION
### Description of the Change
The Superprovider should return the selected account for `getAccounts()` just as a vanilla provider does it.

### Verification Process
From the dapp when using browser network, access `this.web3.eth.getAccounts()` to see one account returned.
Note that until issue #86 is solved, the previously selected account is returned.

### Github Issues
Resolves #66 
