### PR TITLE
Fix contract deployment with argument of type account

### DIFF
--- a/packages/editor/src/reducers/deployer.reducer.ts
+++ b/packages/editor/src/reducers/deployer.reducer.ts
@@ -63,7 +63,7 @@ export default function deployerReducer(state = initialState, action: AnyAction,
             const dappFileData = projects.dappFileData;
 
             // 1. build arguments
-            const contractArgs = normalizeContractArgs(getContractArguments(tree, item, dappFileData));
+            const contractArgs = normalizeContractArgs(getContractArguments(tree, item, dappFileData), projects.accounts);
 
             // 2. check if compilation is fresh
             const findItemResult = findItemById(explorer.tree, item.id);

--- a/packages/editor/src/reducers/deployerLib/normalizeContractArgs.ts
+++ b/packages/editor/src/reducers/deployerLib/normalizeContractArgs.ts
@@ -15,6 +15,7 @@
 // along with Superblocks Lab.  If not, see <http://www.gnu.org/licenses/>.
 
 import { IContractArgData, ContractArgTypes } from '../../models';
+import { IAccount } from '../../models/state';
 
 /**
  * Function to normalize and compile the contract arguments defined by the user to something web3 can use to configure the
@@ -22,7 +23,7 @@ import { IContractArgData, ContractArgTypes } from '../../models';
  *
  * @param contractArgs Contract arguments setup by the user in the Contract Configuration screen
  */
-export function normalizeContractArgs(contractArgs: IContractArgData[]) {
+export function normalizeContractArgs(contractArgs: IContractArgData[], accounts: IAccount[]) {
     const normalizedContractArgs: any[] = [];
     for (const argument of contractArgs) {
         switch (argument.type) {
@@ -31,6 +32,10 @@ export function normalizeContractArgs(contractArgs: IContractArgData[]) {
                 break;
             case ContractArgTypes.array:
                 normalizedContractArgs.push(argument.value.split(','));
+                break;
+            case ContractArgTypes.account:
+                const account = accounts.find(({name}) => name === argument.value);
+                normalizedContractArgs.push(account && account.address);
                 break;
             default:
                 break;


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
Allow construct argument of type account while deploying a contract. More info in #45 
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Verification Process

1.  From Hello World
2. Change HelloWorld.sol to:
```
pragma solidity ^0.5.10;
contract HelloWorld {
    address public message;
    constructor(address initMessage) public {
        message = initMessage;
    }
}
```
3. Go to Configure
4. Change argument type from value to account, then Save
5. Compile and Deploy
6. Check Interact panel, click on the green button and it should return the address of an account

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Github Issues
Resolves #45 
<!-- Enter any applicable Issues here -->
