### PR TITLE
Fix #86 - Superprovider always fed with previously selected account

### DIFF
--- a/packages/editor/src/components/projectEditor/panels/preview/Preview.tsx
+++ b/packages/editor/src/components/projectEditor/panels/preview/Preview.tsx
@@ -57,10 +57,11 @@ export class Preview extends React.Component<IProps> {
 
     componentDidUpdate(prevProps: IProps) {
         const { selectedAccount, htmlToRender } = prevProps;
+        const { refreshContent } = this.props;
 
         if (selectedAccount.name !== this.props.selectedAccount.name) {
-            previewService.setAccount(selectedAccount);
-            this.refreshIframe();
+            previewService.setAccount(this.props.selectedAccount);
+            refreshContent();
         }
 
         if (htmlToRender !== this.props.htmlToRender) {


### PR DESCRIPTION
### Description of the Change
This fixes issue #86 and also another bug when the iframe content was not properly updated when selecting an account.

### Alternate Designs
Not allowing accounts to be changed.

### Benefits
When user changes account, it will actually reflect in the dapp preview code. The user benefits in that it behaves as one would expect.

### Possible Drawbacks
Can't say.

### Verification Process
Access accounts from the dapp, such as `web3.eth.accounts` and `this.web3.eth.getAccounts(...)` and observe that when changing accounts it is no longer the previously selected account which is available in the dapp, but the actual chosen one.
Also the refresh button has to be hit, which is fixed now.

I verified that there are no regressions by staring promptly at the screen for at least 30 seconds.

### Github Issues
Resolves #86
