### PR TITLE
Add external networks to projects dappfiles only

### DIFF
--- a/packages/editor/templates/Coin/dappfile.json
+++ b/packages/editor/templates/Coin/dappfile.json
@@ -8,6 +8,21 @@
     "environments": [
         {
             "name": "browser"
+        },
+        {
+            "name": "custom"
+        },
+        {
+            "name": "rinkeby"
+        },
+        {
+            "name": "ropsten"
+        },
+        {
+            "name": "kovan"
+        },
+        {
+            "name": "mainnet"
         }
     ],
     "contracts": [
@@ -40,6 +55,41 @@
                     "name": "browser",
                     "data": {
                         "wallet": "development",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "custom",
+                    "data": {
+                        "wallet": "private",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "rinkeby",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "ropsten",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "kovan",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "mainnet",
+                    "data": {
+                        "wallet": "external",
                         "index": 0
                     }
                 }

--- a/packages/editor/templates/Crypto Pizzas/dappfile.json
+++ b/packages/editor/templates/Crypto Pizzas/dappfile.json
@@ -2,6 +2,21 @@
     "environments": [
         {
             "name": "browser"
+        },
+        {
+            "name": "custom"
+        },
+        {
+            "name": "rinkeby"
+        },
+        {
+            "name": "ropsten"
+        },
+        {
+            "name": "kovan"
+        },
+        {
+            "name": "mainnet"
         }
     ],
     "contracts": [
@@ -36,6 +51,41 @@
                         "wallet": "development",
                         "index": 0
                     }
+                },
+                {
+                    "name": "custom",
+                    "data": {
+                        "wallet": "private",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "rinkeby",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "ropsten",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "kovan",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "mainnet",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
                 }
             ]
         },
@@ -47,6 +97,13 @@
                     "name": "browser",
                     "data": {
                         "wallet": "development",
+                        "index": 1
+                    }
+                },
+                {
+                    "name": "custom",
+                    "data": {
+                        "wallet": "private",
                         "index": 1
                     }
                 }

--- a/packages/editor/templates/Empty Project/dappfile.json
+++ b/packages/editor/templates/Empty Project/dappfile.json
@@ -2,6 +2,21 @@
     "environments": [
         {
             "name": "browser"
+        },
+        {
+            "name": "custom"
+        },
+        {
+            "name": "rinkeby"
+        },
+        {
+            "name": "ropsten"
+        },
+        {
+            "name": "kovan"
+        },
+        {
+            "name": "mainnet"
         }
     ],
     "contracts": [
@@ -34,6 +49,41 @@
                     "name": "browser",
                     "data": {
                         "wallet": "development",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "custom",
+                    "data": {
+                        "wallet": "private",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "rinkeby",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "ropsten",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "kovan",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "mainnet",
+                    "data": {
+                        "wallet": "external",
                         "index": 0
                     }
                 }

--- a/packages/editor/templates/Hello World/dappfile.json
+++ b/packages/editor/templates/Hello World/dappfile.json
@@ -2,6 +2,21 @@
     "environments": [
         {
             "name": "browser"
+        },
+        {
+            "name": "custom"
+        },
+        {
+            "name": "rinkeby"
+        },
+        {
+            "name": "ropsten"
+        },
+        {
+            "name": "kovan"
+        },
+        {
+            "name": "mainnet"
         }
     ],
     "contracts": [
@@ -39,6 +54,41 @@
                     "name": "browser",
                     "data": {
                         "wallet": "development",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "custom",
+                    "data": {
+                        "wallet": "private",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "rinkeby",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "ropsten",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "kovan",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "mainnet",
+                    "data": {
+                        "wallet": "external",
                         "index": 0
                     }
                 }


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change

As pointed out by @filippsen, the removal of custom networks from the dappfiles of the projects can cause crashes in older projects, when the external networks are enables again. For this reason this PR restores the external networks in the templates.
