### PR TITLE
Hide external networks

### DIFF
--- a/packages/editor/src/components/projectEditor/control/backend.js
+++ b/packages/editor/src/components/projectEditor/control/backend.js
@@ -265,7 +265,22 @@ export default class Backend {
         const environments = [
             {
                 name: 'browser',
-            }
+            },
+            {
+                name: 'custom',
+            },
+            {
+                name: 'rinkeby',
+            },
+            {
+                name: 'ropsten',
+            },
+            {
+                name: 'kovan',
+            },
+            {
+                name: 'mainnet',
+            },
         ];
         const wallets = [
             {
@@ -297,7 +312,42 @@ export default class Backend {
                             wallet: 'development',
                             index: 0,
                         },
-                    }
+                    },
+                    {
+                        name: 'custom',
+                        data: {
+                            wallet: 'private',
+                            index: 0,
+                        },
+                    },
+                    {
+                        name: 'rinkeby',
+                        data: {
+                            wallet: 'external',
+                            index: 0,
+                        },
+                    },
+                    {
+                        name: 'ropsten',
+                        data: {
+                            wallet: 'external',
+                            index: 0,
+                        },
+                    },
+                    {
+                        name: 'kovan',
+                        data: {
+                            wallet: 'external',
+                            index: 0,
+                        },
+                    },
+                    {
+                        name: 'mainnet',
+                        data: {
+                            wallet: 'external',
+                            index: 0,
+                        },
+                    },
                 ],
             },
         ];

--- a/packages/editor/src/components/projectEditor/control/item/dappfileItem.js
+++ b/packages/editor/src/components/projectEditor/control/item/dappfileItem.js
@@ -137,7 +137,22 @@ export default class DappfileItem extends FileItem {
             environments: [
                 {
                     name: 'browser',
-                }
+                },
+                {
+                    name: 'custom',
+                },
+                {
+                    name: 'rinkeby',
+                },
+                {
+                    name: 'ropsten',
+                },
+                {
+                    name: 'kovan',
+                },
+                {
+                    name: 'mainnet',
+                },
             ],
             contracts: [],
             wallets: [
@@ -166,7 +181,42 @@ export default class DappfileItem extends FileItem {
                                 wallet: 'development',
                                 index: 0,
                             },
-                        }
+                        },
+                        {
+                            name: 'custom',
+                            data: {
+                                wallet: 'private',
+                                index: 0,
+                            },
+                        },
+                        {
+                            name: 'rinkeby',
+                            data: {
+                                wallet: 'external',
+                                index: 0,
+                            },
+                        },
+                        {
+                            name: 'ropsten',
+                            data: {
+                                wallet: 'external',
+                                index: 0,
+                            },
+                        },
+                        {
+                            name: 'kovan',
+                            data: {
+                                wallet: 'external',
+                                index: 0,
+                            },
+                        },
+                        {
+                            name: 'mainnet',
+                            data: {
+                                wallet: 'external',
+                                index: 0,
+                            },
+                        },
                     ],
                 },
             ],

--- a/packages/editor/src/epics/account/createNewAccount.epic.ts
+++ b/packages/editor/src/epics/account/createNewAccount.epic.ts
@@ -40,6 +40,12 @@ export const createNewAccountEpic = (action$: AnyAction, state$: any) => action$
                         wallet: 'development',
                         index: accounts.length
                     }
+                }, {
+                    name: 'custom',
+                    data: {
+                        wallet: 'private',
+                        index: accounts.length
+                    }
                 }]
             };
 

--- a/packages/editor/src/networks.ts
+++ b/packages/editor/src/networks.ts
@@ -13,6 +13,36 @@ const Networks: INetworkRecord = {
         chainId: undefined,
         interval: 1000,
         name: 'browser'
+    },
+    custom: {
+        endpoint: 'http://localhost:8545/',
+        chainId: undefined,
+        interval: 2000,
+        name: 'custom'
+    },
+    kovan: {
+        endpoint: `https://kovan.infura.io/v3/${INFURA_API_KEY}`,
+        chainId: 42,
+        interval: 5000,
+        name: 'kovan'
+    },
+    mainnet: {
+        endpoint: `https://mainnet.infura.io/v3/${INFURA_API_KEY}`,
+        chainId: 1,
+        interval: 10000,
+        name: 'mainnet'
+    },
+    ropsten: {
+        endpoint: `https://ropsten.infura.io/v3/${INFURA_API_KEY}`,
+        chainId: 3,
+        interval: 2500,
+        name: 'ropsten'
+    },
+    rinkeby: {
+        endpoint: `https://rinkeby.infura.io/v3/${INFURA_API_KEY}`,
+        chainId: 4,
+        interval: 2500,
+        name: 'rinkeby'
     }
 };
 

--- a/packages/editor/src/selectors/project.selectors.ts
+++ b/packages/editor/src/selectors/project.selectors.ts
@@ -17,7 +17,8 @@ import { IAccount, IEnvironment } from '../models/state';
 import { IProject } from '../models';
 
 export const projectSelectors = {
-    getEnvironments: (state: any) => state.projects.environments,
+    // TODO enable external environments
+    getEnvironments: (state: any) => state.projects.environments.slice(0, 1).map((env: any) => env),
     getAccounts: (state: any) => state.projects.accounts,
     getSelectedEnvironment: (state: any): IEnvironment => state.projects.selectedEnvironment,
     getSelectedAccount: (state: any): IAccount => state.projects.selectedAccount,

--- a/packages/editor/templates/Coin/dappfile.json
+++ b/packages/editor/templates/Coin/dappfile.json
@@ -8,6 +8,21 @@
     "environments": [
         {
             "name": "browser"
+        },
+        {
+            "name": "custom"
+        },
+        {
+            "name": "rinkeby"
+        },
+        {
+            "name": "ropsten"
+        },
+        {
+            "name": "kovan"
+        },
+        {
+            "name": "mainnet"
         }
     ],
     "contracts": [
@@ -40,6 +55,41 @@
                     "name": "browser",
                     "data": {
                         "wallet": "development",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "custom",
+                    "data": {
+                        "wallet": "private",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "rinkeby",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "ropsten",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "kovan",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "mainnet",
+                    "data": {
+                        "wallet": "external",
                         "index": 0
                     }
                 }

--- a/packages/editor/templates/Crypto Pizzas/dappfile.json
+++ b/packages/editor/templates/Crypto Pizzas/dappfile.json
@@ -2,6 +2,21 @@
     "environments": [
         {
             "name": "browser"
+        },
+        {
+            "name": "custom"
+        },
+        {
+            "name": "rinkeby"
+        },
+        {
+            "name": "ropsten"
+        },
+        {
+            "name": "kovan"
+        },
+        {
+            "name": "mainnet"
         }
     ],
     "contracts": [
@@ -36,6 +51,41 @@
                         "wallet": "development",
                         "index": 0
                     }
+                },
+                {
+                    "name": "custom",
+                    "data": {
+                        "wallet": "private",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "rinkeby",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "ropsten",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "kovan",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "mainnet",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
                 }
             ]
         },
@@ -47,6 +97,13 @@
                     "name": "browser",
                     "data": {
                         "wallet": "development",
+                        "index": 1
+                    }
+                },
+                {
+                    "name": "custom",
+                    "data": {
+                        "wallet": "private",
                         "index": 1
                     }
                 }

--- a/packages/editor/templates/Empty Project/dappfile.json
+++ b/packages/editor/templates/Empty Project/dappfile.json
@@ -2,6 +2,21 @@
     "environments": [
         {
             "name": "browser"
+        },
+        {
+            "name": "custom"
+        },
+        {
+            "name": "rinkeby"
+        },
+        {
+            "name": "ropsten"
+        },
+        {
+            "name": "kovan"
+        },
+        {
+            "name": "mainnet"
         }
     ],
     "contracts": [
@@ -34,6 +49,41 @@
                     "name": "browser",
                     "data": {
                         "wallet": "development",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "custom",
+                    "data": {
+                        "wallet": "private",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "rinkeby",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "ropsten",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "kovan",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "mainnet",
+                    "data": {
+                        "wallet": "external",
                         "index": 0
                     }
                 }

--- a/packages/editor/templates/Hello World/dappfile.json
+++ b/packages/editor/templates/Hello World/dappfile.json
@@ -2,6 +2,21 @@
     "environments": [
         {
             "name": "browser"
+        },
+        {
+            "name": "custom"
+        },
+        {
+            "name": "rinkeby"
+        },
+        {
+            "name": "ropsten"
+        },
+        {
+            "name": "kovan"
+        },
+        {
+            "name": "mainnet"
         }
     ],
     "contracts": [
@@ -39,6 +54,41 @@
                     "name": "browser",
                     "data": {
                         "wallet": "development",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "custom",
+                    "data": {
+                        "wallet": "private",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "rinkeby",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "ropsten",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "kovan",
+                    "data": {
+                        "wallet": "external",
+                        "index": 0
+                    }
+                },
+                {
+                    "name": "mainnet",
+                    "data": {
+                        "wallet": "external",
                         "index": 0
                     }
                 }


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change

As pointed out by @filippsen, the removal of custom networks from the dappfiles of the projects can cause crashes in older projects, when the external networks are enables again. For this reason this PR reverts all changes in commit "remove all external networks" and only hides the external options in the UI.