### PR TITLE
Fix forced scroll inside embedded Studio

### DIFF
--- a/packages/editor/src/components/projectEditor/panels/messagesPanel/MessagesPanel.tsx
+++ b/packages/editor/src/components/projectEditor/panels/messagesPanel/MessagesPanel.tsx
@@ -41,7 +41,7 @@ export const MessagesPanel = (props: IProps) => {
 
     const scrollToBottom = () => {
         if (messagesAnchor !== null && messagesAnchor.current !== null) {
-            messagesAnchor.current.scrollIntoView({ behavior: 'smooth' });
+            messagesAnchor.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
         }
     };
 

--- a/packages/editor/src/components/projectEditor/panels/output/OutputPanel.tsx
+++ b/packages/editor/src/components/projectEditor/panels/output/OutputPanel.tsx
@@ -31,7 +31,7 @@ export const OutputPanel = (props: IProps) => {
 
     const scrollToBottom = () => {
         if (messagesAnchor !== null && messagesAnchor.current !== null) {
-            messagesAnchor.current.scrollIntoView({ behavior: 'smooth' });
+            messagesAnchor.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
         }
     };
 


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
When trying to compile or deploy inside embedded Studio, it would unexpectedly scroll whole window, instead the Output panel itself. You can try it here, by compiling from any iframe:
https://superblocks.com/ethereum-studio/

This PR shall fix this.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->
