### PR TITLE
Fix build type when creating the docker image

### DIFF
--- a/superblocks.yaml
+++ b/superblocks.yaml
@@ -10,7 +10,7 @@ jobs:
       - docker:18.09.7-dind
     script:
       - echo "$GITHUB_REGISTRY_TOKEN" | docker login docker.pkg.github.com --username $GITHUB_REGISTRY_USER --password-stdin
-      - docker build --build-arg BUILD=build:prod -t $GITHUB_REGISTRY_IMAGE:$SUPER_COMMIT_SHA1 .
+      - docker build --build-arg BUILD=build -t $GITHUB_REGISTRY_IMAGE:$SUPER_COMMIT_SHA1 .
       - docker push $GITHUB_REGISTRY_IMAGE:$SUPER_COMMIT_SHA1
 
   deploy_to_dev:

--- a/superblocks.yaml
+++ b/superblocks.yaml
@@ -10,7 +10,7 @@ jobs:
       - docker:18.09.7-dind
     script:
       - echo "$GITHUB_REGISTRY_TOKEN" | docker login docker.pkg.github.com --username $GITHUB_REGISTRY_USER --password-stdin
-      - docker build --build-arg BUILD=build:dev -t $GITHUB_REGISTRY_IMAGE:$SUPER_COMMIT_SHA1 .
+      - docker build --build-arg BUILD=build:prod -t $GITHUB_REGISTRY_IMAGE:$SUPER_COMMIT_SHA1 .
       - docker push $GITHUB_REGISTRY_IMAGE:$SUPER_COMMIT_SHA1
 
   deploy_to_dev:


### PR DESCRIPTION
### Description of the Change

Fix the build type when creating the docker image to be uploaded to the registry during the CI process. 

Currently, we are actually deploying the `build:dev` version!! 