### PR TITLE
Fix renaming of account

### DIFF
--- a/packages/editor/src/reducers/projects.reducer.ts
+++ b/packages/editor/src/reducers/projects.reducer.ts
@@ -20,6 +20,7 @@ import { IProjectItem } from '../models';
 import { getDappSettings, resolveAccounts } from './dappfileLib';
 import { authActions, accountActions, panesActions, projectsActions } from '../actions';
 import { findItemById } from './explorerLib';
+import { replaceInArray } from './utils';
 
 export const initialState: IProjectState = {
     project: {
@@ -251,6 +252,20 @@ export default function projectsReducer(state = initialState, action: AnyAction,
             return {
                 ...state,
                 ...stateChange
+            };
+        }
+        case accountActions.UPDATE_ACCOUNT_NAME: {
+            return {
+                ...state,
+                accounts: replaceInArray(
+                    state.accounts,
+                    acc => acc.name === action.data.account.name,
+                    acc => ({ ...acc, name: action.data.newName })
+                ),
+                selectedAccount: {
+                    ...state.selectedAccount,
+                    name: state.selectedAccount.name === action.data.account.name ? action.data.newName : state.selectedAccount.name
+                }
             };
         }
         default:


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
- This should fix the bug with renaming account, more info in #92 


### Verification Process

1. Create a New Account from topbar dropdown (Select an Account)
2. Try to rename newly created Account1 to Patata
3. It should update properly in the dropdown of account selector
4. Try to rename the Account1 once again to Patata
5. It should also rename properly

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Github Issues
Resolves #92 
<!-- Enter any applicable Issues here -->
