### PR TITLE
Fix firefox interact and enable external networks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5439,6 +5439,10 @@
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
 		},
+		"bignumber.js": {
+			"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+			"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+		},
 		"binary-extensions": {
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -8754,6 +8758,7 @@
 					"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
 					"integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
 					"requires": {
+						"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
 						"crypto-js": "^3.1.4",
 						"utf8": "^2.1.1",
 						"xhr2-cookies": "^1.1.0",
@@ -8762,7 +8767,7 @@
 					"dependencies": {
 						"bignumber.js": {
 							"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-							"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+							"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
 						}
 					}
 				}
@@ -10516,7 +10521,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -10534,11 +10540,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -10551,15 +10559,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -10662,7 +10673,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -10672,6 +10684,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -10684,17 +10697,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -10711,6 +10727,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -10783,7 +10800,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -10793,6 +10811,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -10868,7 +10887,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -10898,6 +10918,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -10915,6 +10936,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -10953,11 +10975,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},
@@ -26311,20 +26335,17 @@
 			}
 		},
 		"web3": {
-			"version": "0.20.7",
-			"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
-			"integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
+			"version": "0.20.6",
+			"resolved": "https://registry.npmjs.org/web3/-/web3-0.20.6.tgz",
+			"integrity": "sha1-PpcwauAk+yThCj11yIQwJWIhUSA=",
 			"requires": {
+				"bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
 				"crypto-js": "^3.1.4",
 				"utf8": "^2.1.1",
-				"xhr2-cookies": "^1.1.0",
+				"xhr2": "*",
 				"xmlhttprequest": "*"
 			},
 			"dependencies": {
-				"bignumber.js": {
-					"version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-					"from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-				},
 				"crypto-js": {
 					"version": "3.1.8",
 					"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
@@ -27689,6 +27710,11 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
 			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+		},
+		"xhr2": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.0.tgz",
+			"integrity": "sha512-BDtiD0i2iKPK/S8OAZfpk6tyzEDnKKSjxWHcMBVmh+LuqJ8A32qXTyOx+TVOg2dKvq6zGBq2sgKPkEeRs1qTRA=="
 		},
 		"xhr2-cookies": {
 			"version": "1.1.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -153,7 +153,7 @@
     "showdown": "^1.9.0",
     "showdown-highlight": "^2.1.3",
     "solc": "^0.5.10",
-    "web3": "0.20.7"
+    "web3": "0.20.6"
   },
   "browserslist": [
     ">0.2%",

--- a/packages/editor/src/epics/interact/sendTransaction.epic.ts
+++ b/packages/editor/src/epics/interact/sendTransaction.epic.ts
@@ -114,8 +114,8 @@ function doSendExternally$(environment: IEnvironment, selectedAccount: IAccount,
             concat(
                 of(outputLogActions.addRows([ result ])),
                 of(deployerActions.hideExternalProviderInfo()),
-                of(transactionsActions.addTransaction(TransactionType.Interact, result.hash, undefined, result.contractName),
-                of(transactionsActions.checkSentTransactions(environment.endpoint, contractName))),
+                of(transactionsActions.checkSentTransactions(environment.endpoint, contractName)),
+                of(transactionsActions.addTransaction(TransactionType.Interact, result.hash, undefined, result.contractName)),
                 // finalizeDeploy(state, deployRunner, result.hash, state.deployer.outputPath, false)
             )
         ),

--- a/packages/editor/src/selectors/project.selectors.ts
+++ b/packages/editor/src/selectors/project.selectors.ts
@@ -17,8 +17,7 @@ import { IAccount, IEnvironment } from '../models/state';
 import { IProject } from '../models';
 
 export const projectSelectors = {
-    // TODO enable external environments
-    getEnvironments: (state: any) => state.projects.environments.slice(0, 1).map((env: any) => env),
+    getEnvironments: (state: any) => state.projects.environments,
     getAccounts: (state: any) => state.projects.accounts,
     getSelectedEnvironment: (state: any): IEnvironment => state.projects.selectedEnvironment,
     getSelectedAccount: (state: any): IAccount => state.projects.selectedAccount,

--- a/packages/editor/src/services/utils/web3Utils.ts
+++ b/packages/editor/src/services/utils/web3Utils.ts
@@ -16,6 +16,7 @@
 
 import Networks from '../../networks';
 import { evmService } from '..';
+import Web3 from 'web3';
 
 export function getWeb3(endpoint: string) {
     let provider;
@@ -25,7 +26,8 @@ export function getWeb3(endpoint: string) {
         provider = new window.Web3.providers.HttpProvider(endpoint);
     }
 
-    return new window.Web3(provider);
+    window.Web3 = new Web3(provider);
+    return window.Web3;
 }
 
 export function convertGas(value: string) {


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
This PR rolls back the version of Web3 to an earlier version, which doesn't have the CORS bug, thus fixes the problem of interact in the Firefox browser. It also forces Metamask to use our own version of Web3, intstead of injecting their own.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Benefits
Interact panel works again with Firefox with external networks.

### Github Issues
Resolves #65 
Resolves #102 
Resolves #104 

---
Related:
Resolves #42 
Resolves #55 