### PR TITLE
Fix 'Download' button not working when preview window is closed

### DIFF
--- a/packages/editor/src/epics/preview/tryToDownload.epic.ts
+++ b/packages/editor/src/epics/preview/tryToDownload.epic.ts
@@ -14,12 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with Superblocks Lab.  If not, see <http://www.gnu.org/licenses/>.
 
-import { downloadEpic } from './download.epic';
-import { toggleWeb3AccountsEpic } from './toggleWeb3Accounts.epic';
-import { tryToDownloadEpic } from './tryToDownload.epic';
+import { switchMap, withLatestFrom } from 'rxjs/operators';
+import { Epic, ofType } from 'redux-observable';
+import { panelsActions, previewActions } from '../../actions';
+import { EMPTY } from 'rxjs';
+import { Panels } from '../../models/state';
 
-export const previewEpics = [
-    downloadEpic,
-    toggleWeb3AccountsEpic,
-    tryToDownloadEpic
-];
+export const tryToDownloadEpic: Epic = (action$: any, state$: any) => action$.pipe(
+    ofType(previewActions.TRY_DOWNLOAD),
+    withLatestFrom(state$),
+    switchMap(([_, state]) => {
+        if (!state.panels.Preview.open) {
+            return [panelsActions.openPanel(Panels.Preview)];
+        }
+
+        return EMPTY;
+    })
+);


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
As the creation of the exportable html is tied to the Preview window, this PR automatically opens the it when the download button is clicked, so that the html can be downloaded.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->


### Verification Process
Close preview window and hit 'Download' from the menu. 
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Github Issues

<!-- Enter any applicable Issues here -->
Resolves #116