### PR TITLE
Fixed compilation related fork

### DIFF
--- a/packages/editor/src/epics/compiler/initCompilation.epic.ts
+++ b/packages/editor/src/epics/compiler/initCompilation.epic.ts
@@ -36,13 +36,10 @@ function compileContract(compilerState: any) {
 export const initCompilation: Epic = (action$: any, state$: any) => action$.pipe(
     ofType(compilerActions.INIT_COMPILATION),
     withLatestFrom(state$),
-    switchMap(([action, state]) => {
-
+    switchMap(([, state]) => {
         const project = projectSelectors.getProject(state);
-        const files = action.data.files;
         const isOwnProject = state.projects.isOwnProject;
 
-        console.log(files);
         if (isOwnProject) {
             compilerService.init();
             return concat(
@@ -56,7 +53,7 @@ export const initCompilation: Epic = (action$: any, state$: any) => action$.pipe
                 )
             );
         } else {
-            return [projectsActions.createForkedProject(project.name, project.description, files)];
+            return [projectsActions.forkProject(project.id, true)];
         }
     })
 );


### PR DESCRIPTION
### Description of the Change

Fix the forking of a project when trying to compile a project which does not belong to you. The main issue was that the `initCompilation` epic was wrongly assuming the action had a `files` property. 

With this method of forking, we simply pull the latest from the server and fork it. 

### Verification Process

1. Open this project http://localhost:4000/5dd403dd7cbff7b64f2119ff?openFile=README.md
2. Expand the HelloWorld.sol file and try to compile it. 
3. The newly created projects should be correctly forked
