### PR TITLE
Add details on how people can use empty template to create projects

### DIFF
--- a/packages/editor/templates/Empty Project/README.md
+++ b/packages/editor/templates/Empty Project/README.md
@@ -1,7 +1,11 @@
-# Empty DApp project
+# Empty dapp project
 
-This is a bare bones dapp project containing a smart contract and boilerplate app files to get started.
+This is a bare bones dapp project containing a smart contract and boilerplate app files to get started, or to create a template to use with Studio.
 
 ## Where to go from here
 
-Check out the tutorials to find our more how to build your dapp.
+1.  Try the other tutorials to find out more how to build a dapp.
+2.  Build!
+3.  Click the _Share_ button in the top toolbar, there are several ways to share your project to the world.
+    1.  Submit a tutorial to [Kauri.io](https://kauri.io/write-article), remember you can embed Studio projects in the article from the share button.
+    2.  If you want your project considered as a default template for new learners, [open a pull request](https://github.com/SuperblocksHQ/ethereum-studio/pulls) to our GitHub repository with your project inside _packages/templates_.


### PR DESCRIPTION
## Description of the Change

A few people have asked how they can (potentially) add templates to the template  chooser. I don't think we want to add everything people suggest or the list will be very  long,  but  I thought I'd update the empty  project readme to explain what people could do next.

I'll also add something along these lines to the opening dialogue, and the new video.
