### PR TITLE
Edit account name in one click

### DIFF
--- a/packages/editor/src/components/accountSelector/accountsList.tsx
+++ b/packages/editor/src/components/accountSelector/accountsList.tsx
@@ -61,14 +61,15 @@ export class AccountsList extends Component<IProps, IState> {
     componentDidUpdate(prevProps: IProps) {
         if (prevProps.selectedAccount.name !== this.props.selectedAccount.name) {
             this.setState({
-                isButtonClicked: false,
                 newAccountName: this.props.selectedAccountName
             });
         }
     }
 
-    onEditClick = (e: React.MouseEvent, index: number) => {
+    onEditClick = (e: React.MouseEvent, index: number, account: IAccount) => {
+        e.stopPropagation();
         this.setState({ isButtonClicked: true, stateIndex: index });
+        this.props.onSelect(account);
     }
 
     onDeleteClick = (e: React.MouseEvent, account: IAccount) => {
@@ -98,6 +99,12 @@ export class AccountsList extends Component<IProps, IState> {
             errorName
         });
 
+    }
+
+    onSelectAccount = (e: React.MouseEvent, account: IAccount) => {
+        e.stopPropagation();
+        this.setState({ isButtonClicked: false });
+        this.props.onSelect(account);
     }
 
     handleKeyDown = (e: any) => {
@@ -144,7 +151,7 @@ export class AccountsList extends Component<IProps, IState> {
             return (
                 <div key={index}>
                     <div className={classnames(style.accountLink, { [style.accountLinkChosen]: account.name === this.props.selectedAccountName })}
-                        onClick={() => this.props.onSelect(account)}>
+                        onClick={(e) => this.onSelectAccount(e, account)}>
 
                         <div className={style.nameContainer}>
                             <div className={style.accountName}>
@@ -164,7 +171,7 @@ export class AccountsList extends Component<IProps, IState> {
                             <div className={style.address}>{accountUtils.shortenAddres(account.address || '')}</div>
                         </div>
                         <div className={isButtonClicked && stateIndex === index ? style.actionsContainerClicked : style.actionsContainer}>
-                            <button className='btnNoBg' onClick={(e) => this.onEditClick(e, index)}>
+                            <button className='btnNoBg' onClick={(e) => this.onEditClick(e, index, account)}>
                                 <Tooltip title='Edit account name'>
                                     <IconEdit />
                                 </Tooltip>

--- a/packages/editor/src/components/accountSelector/accountsList.tsx
+++ b/packages/editor/src/components/accountSelector/accountsList.tsx
@@ -69,7 +69,7 @@ export class AccountsList extends Component<IProps, IState> {
     onEditClick = (e: React.MouseEvent, index: number, account: IAccount) => {
         e.stopPropagation();
         this.setState({ isButtonClicked: true, stateIndex: index });
-        this.props.onSelect(account);
+        // this.props.onSelect(account);
     }
 
     onDeleteClick = (e: React.MouseEvent, account: IAccount) => {
@@ -82,13 +82,13 @@ export class AccountsList extends Component<IProps, IState> {
         this.props.onCreate();
     }
 
-    onNameChange = (e: any) => {
+    onNameChange = (e: any, account: IAccount) => {
         const value = e.target.value;
-        const { selectedAccount, accounts } = this.props;
+        const { accounts } = this.props;
         const isDuplicate = accounts.find((acc) => acc.name === value);
 
         let errorName = null;
-        if (!!isDuplicate && selectedAccount.name !== value) {
+        if (!!isDuplicate && account.name !== value) {
             errorName = 'Account with such name already exists, please choose a different one.';
         } else {
             errorName = validateAccountName(value);
@@ -107,14 +107,14 @@ export class AccountsList extends Component<IProps, IState> {
         this.props.onSelect(account);
     }
 
-    handleKeyDown = (e: any) => {
+    handleKeyDown = (e: any, account: IAccount) => {
         if (e.key === 'Enter') {
-            this.saveName(e);
+            this.saveName(e, account);
         }
     }
 
-    saveName = (e: any) => {
-        const { selectedAccount: account, updateAccountName } = this.props;
+    saveName = (e: any, account: IAccount) => {
+        const { updateAccountName } = this.props;
         const { newAccountName, errorName } = this.state;
         e.preventDefault();
         if (!errorName) {
@@ -159,11 +159,12 @@ export class AccountsList extends Component<IProps, IState> {
                                     <TextInput
                                         type='text'
                                         id='name'
-                                        value={newAccountName || ''}
-                                        onBlur={this.saveName}
-                                        onKeyDown={this.handleKeyDown}
-                                        onChange={this.onNameChange}
+                                        onBlur={(e: any) => this.saveName(e, account)}
+                                        onKeyDown={(e: any) => this.handleKeyDown(e, account)}
+                                        onChange={(e: any) => this.onNameChange(e, account)}
+                                        onClick={(e: any) => e.stopPropagation()}
                                         error={errorName}
+                                        defaultValue={account.name}
                                     />
                                     : <div>{account.name}</div>
                                 }

--- a/packages/editor/src/components/accountSelector/style.less
+++ b/packages/editor/src/components/accountSelector/style.less
@@ -73,7 +73,6 @@
             padding-left: 20px;
             padding-right: 12px;
             line-height: 40px;
-            border-left: 2px solid;
             border-color: transparent;
             margin: 0;
             .accountName {

--- a/packages/editor/src/components/projectEditor/panels/preview/style.less
+++ b/packages/editor/src/components/projectEditor/panels/preview/style.less
@@ -19,7 +19,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    margin-bottom: 30px;
 
     .toolbar {
         background-color: #1e1e1e;

--- a/packages/editor/src/components/projectEditor/panels/preview/style.less
+++ b/packages/editor/src/components/projectEditor/panels/preview/style.less
@@ -19,6 +19,7 @@
     height: 100%;
     display: flex;
     flex-direction: column;
+    margin-bottom: 30px;
 
     .toolbar {
         background-color: #1e1e1e;

--- a/packages/editor/src/components/projectEditor/style-console.less
+++ b/packages/editor/src/components/projectEditor/style-console.less
@@ -21,7 +21,6 @@
     width: 100%;
     height: 100%;
     display: flex;
-    padding-bottom: 30px;
 
     .actionMenu {
         display: flex;

--- a/packages/editor/src/components/projectEditor/style.less
+++ b/packages/editor/src/components/projectEditor/style.less
@@ -66,6 +66,10 @@
     .rightPanel {
         height: 100%;
         display: flex;
+
+        .rightSplitter {
+            height: calc(100% - 30px);
+        }
     }
 
     .panelButtonsContainer {


### PR DESCRIPTION

<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
Fixed padding on the bottom of the browser, now it is not being cut anymore. When you click edit account name of the not selected account it will automatically open the text input and select an account. Removed the green line on the select account hover because I think it looks better that way.
<!--
