### PR TITLE
Fix: Clicking outside of dropdown/menu should exit this component

### DIFF
--- a/packages/editor/src/components/accountSelector/accountSelector.tsx
+++ b/packages/editor/src/components/accountSelector/accountSelector.tsx
@@ -45,19 +45,20 @@ export class AccountSelector extends React.Component<IProps> {
         const { selectedAccount, accounts, accountInfo } = this.props;
         return (
             <DropdownContainer
-                enableClickInside={true}
                 dropdownContent={
-                    <AccountsList
-                        accountInfo={accountInfo}
-                        updateAccountName={this.props.updateAccountName}
-                        accounts={accounts}
-                        selectedAccount={selectedAccount}
-                        selectedAccountName={selectedAccount.name}
-                        onSelect={this.props.onAccountSelected}
-                        onEdit={this.props.onAccountEdit}
-                        onDelete={this.onDeleteAccountClick}
-                        onCreate={this.props.onAccountCreate}
-                    />
+                    <div className={style.dropdownWrapper}>
+                        <AccountsList
+                            accountInfo={accountInfo}
+                            updateAccountName={this.props.updateAccountName}
+                            accounts={accounts}
+                            selectedAccount={selectedAccount}
+                            selectedAccountName={selectedAccount.name}
+                            onSelect={this.props.onAccountSelected}
+                            onEdit={this.props.onAccountEdit}
+                            onDelete={this.onDeleteAccountClick}
+                            onCreate={this.props.onAccountCreate}
+                        />
+                    </div>
                 }
             >
                 <div className={classnames([style.selector, style.account])}>

--- a/packages/editor/src/components/accountSelector/style.less
+++ b/packages/editor/src/components/accountSelector/style.less
@@ -54,10 +54,17 @@
             text-transform: capitalize
         }
     }
-    .accounts {
+    .dropdownWrapper {
         position: fixed;
+        left: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
+    }
+    .accounts {
+        position: absolute;
+        top: 43px;
         right: 8px;
-        margin-top: 9px;
         background-color: #2a2a2a;
         width: 346px;
         box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .50);


### PR DESCRIPTION
<!--

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

* Please provide relevant tests to make sure we can keep improving our coverage and try to minizime regressions while developing the app.

-->


### Description of the Change
- This should fix the issue when clicking outside of the account selector component it wouldn't hide the component. It was working correctly, only problem was when clicking on the iframe - (browser preview) - it wouldn't hide it.
<!--

### Benefits
- With this change it should work as is supposed to
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
- Because the issue was due to the iframe, which doesn't have onClick events, I had to make the dropdown similar to modal. Meaning that there is now a wrapper component around it. So the drawback is that when clicking outside on the first click, it won't trigger the events, if any, it will just hide the account selector component.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
1. Click on Account selector
2. Click anywhere but the account selector
3. It should hide the component
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Github Issues
Resolves #208 
<!-- Enter any applicable Issues here -->
